### PR TITLE
Added option to prescribe velocity field instead of solving N-S

### DIFF
--- a/src/initflow.f90
+++ b/src/initflow.f90
@@ -13,7 +13,7 @@ module mod_initflow
   private
   public initflow,initscal,add_noise
   contains
-  subroutine initflow(inivel,bcvel,ng,lo,l,dl,zc,zf,dzc,dzf,rho,mu,bforce,is_wallturb,u,v,w,p)
+  subroutine initflow(inivel,bcvel,ng,lo,l,dl,zc,zf,dzc,dzf,rho,mu,bforce,is_wallturb,time,u,v,w,p)
     !
     ! computes initial conditions for the velocity field
     !
@@ -26,6 +26,7 @@ module mod_initflow
     real(rp), intent(in)               :: rho,mu
     real(rp), intent(in), dimension(3) :: bforce
     logical , intent(in)               :: is_wallturb
+    real(rp), intent(in)               :: time
     real(rp), dimension(0:,0:,0:), intent(out) :: u,v,w,p
     real(rp), allocatable, dimension(:) :: u1d
     !real(rp), allocatable, dimension(:,:) :: u2d

--- a/src/input.nml
+++ b/src/input.nml
@@ -3,6 +3,7 @@ ng(1:3) = 64, 64,  64
 l(1:3)  = 1., 1., 1.
 gtype = 1, gr = 0.
 cfl = 0.95, dtmin = 1.e-4
+is_solve_ns = T
 inivel = 'zer', inisca = 'uni'
 is_wallturb = F
 nstep = 11, time_max = 100., tw_max = 0.1

--- a/src/param.f90
+++ b/src/param.f90
@@ -28,6 +28,7 @@ real(rp), protected, dimension(3) :: l
 integer , protected :: gtype
 real(rp), protected :: gr
 real(rp), protected :: cfl,dtmin
+logical , protected :: is_solve_ns
 !
 character(len=100), protected :: inivel,inisca
 logical, protected :: is_wallturb
@@ -85,6 +86,7 @@ contains
                   l, &
                   gtype,gr, &
                   cfl,dtmin, &
+                  is_solve_ns, &
                   inivel,inisca, &
                   is_wallturb, &
                   nstep,time_max,tw_max, &


### PR DESCRIPTION
Making it easier to benchmark interface-capturing schemes. One just needs to add the time-depepdent initial condition under `initflow.f90` (`time` is not an input parameter).