### PR TITLE
New acdi rglr

### DIFF
--- a/src/main.f90
+++ b/src/main.f90
@@ -345,7 +345,8 @@ program cans
     !
     ! Phase field update
     !
-    call tm_2fl(tm_coeff,n,dli,dzci,dzfi,dt,gam,seps,u,v,w,normx,normy,normz,psi)
+    call tm_2fl(tm_coeff,n,dli,dzci,dzfi,dt,gam,seps,u,v,w,normx,normy,normz,psi,rglrx,rglry,rglrz)
+    call bounduvw(cbcvel,n,bcvel,nb,is_bound,.false.,dl,dzc,dzf,rglrx,rglry,rglrz)
     call boundp(cbcpsi,n,bcpsi,nb,is_bound,dl,dzc,psi)
     call acdi_cmpt_norm_curv(n,dli,dzci,dzfi,seps,psi,kappa,normx,normy,normz)
     call boundp(cbcpsi,n,bcpre,nb,is_bound,dl,dzc,kappa)
@@ -366,8 +367,8 @@ program cans
       if(any(abs(gacc(:))>0. .and. cbcpre(0,:)//cbcpre(1,:) == 'PP')) then
         call bulk_mean_12(n,grid_vol_ratio_c,psi,rho12,rho_av)
       end if
-      call acdi_cmpt_rglr(n,dli,dzci,dzfi,gam,seps,normx,normy,normz,psi,rglrx,rglry,rglrz) ! maybe I need to store and use the old rglr instead
-      call bounduvw(cbcvel,n,bcvel,nb,is_bound,.false.,dl,dzc,dzf,rglrx,rglry,rglrz)
+      !call acdi_cmpt_rglr(n,dli,dzci,dzfi,gam,seps,normx,normy,normz,psi,rglrx,rglry,rglrz) ! maybe I need to store and use the old rglr instead
+      !call bounduvw(cbcvel,n,bcvel,nb,is_bound,.false.,dl,dzc,dzf,rglrx,rglry,rglrz)
       call tm(tm_coeff,n,dli,dzci,dzfi,dt, &
             bforce,gacc,sigma,rho_av,rho12,mu12,beta12,rho0,psi,kappa,s, &
             p,pp,rglrx,rglry,rglrz,u,v,w)

--- a/src/rk.f90
+++ b/src/rk.f90
@@ -169,7 +169,7 @@ module mod_rk
     call swap(dsdtrk,dsdtrko)
   end subroutine rk_scal
   !
-  subroutine rk_2fl(rkpar,n,dli,dzci,dzfi,dt,gam,seps,u,v,w,normx,normy,normz,psi)
+  subroutine rk_2fl(rkpar,n,dli,dzci,dzfi,dt,gam,seps,u,v,w,normx,normy,normz,psi,rglrx,rglry,rglrz)
     use mod_acdi     , only: acdi_transport_pf
     use mod_two_fluid, only: clip_field
     !
@@ -186,6 +186,7 @@ module mod_rk
     real(rp), intent(in   ), dimension(0:,0:,0:) :: u,v,w
     real(rp), intent(in   ), dimension(0:,0:,0:) :: normx,normy,normz
     real(rp), intent(inout), dimension(0:,0:,0:) :: psi
+    real(rp), intent(out), dimension(0:,0:,0:) :: rglrx,rglry,rglrz
     real(rp), target     , allocatable, dimension(:,:,:), save :: dpsidtrk_t,dpsidtrko_t
     real(rp), pointer    , contiguous , dimension(:,:,:), save :: dpsidtrk  ,dpsidtrko
     logical, save :: is_first = .true.
@@ -201,7 +202,7 @@ module mod_rk
       dpsidtrk  => dpsidtrk_t
       dpsidtrko => dpsidtrko_t
     end if
-    call acdi_transport_pf(n,dli,dzci,dzfi,gam,seps,u,v,w,normx,normy,normz,psi,dpsidtrk)
+    call acdi_transport_pf(n,dli,dzci,dzfi,gam,seps,u,v,w,normx,normy,normz,psi,dpsidtrk,rglrx,rglry,rglrz)
     if(is_first) then ! use Euler forward
       !$acc kernels
       dpsidtrko(:,:,:) = dpsidtrk(:,:,:)


### PR DESCRIPTION
Interface regularization term is now directly an output of `acdi_transport_pf`.
Byproduct: regularization term in the momentum RHS is now div(**f**_n **u**_n), previously it was div(**f**_n+1 **u**_n).