### PR TITLE
Fix time step stability criterion.

### DIFF
--- a/src/chkdt.f90
+++ b/src/chkdt.f90
@@ -76,7 +76,7 @@ module mod_chkdt
       dtiv = maxval(mu12(:)/rho12(:))*2.*(3./dlmin**2)
       dtik = sqrt(sigma/(minval(rho12(:)))/dlmin**3)
       dtig = maxval(abs(gacc))/dlmin
-      dti = 2.*(dti+dtiv+sqrt((dti+dtiv)**2+4.*(dtig**2+dtik**2))) !TODO: follow Kang's paper to include dtipsi in the single dti formula, if is_solve_ns = .true.
+      dti = 0.5*(dti+dtiv+sqrt((dti+dtiv)**2+4.*(dtig**2+dtik**2))) !TODO: follow Kang's paper to include dtipsi in the single dti formula, if is_solve_ns = .true.
       if(dti    == 0.) dti    = 1.
       if(dtipsi == 0.) dtipsi = 1.
       dtmax = min(dti**(-1),dtipsi**(-1))


### PR DESCRIPTION
Pre-factor should be `0.5` and not `2.0`. Perhaps this will have implications for the stability of the examples and tests, we should probably check before merging.