### PR TITLE
Update docs.

### DIFF
--- a/docs/INFO_COMPILING.md
+++ b/docs/INFO_COMPILING.md
@@ -34,8 +34,10 @@ In this file, `FCOMP` can be one of `GNU` (`gfortran`), `INTEL` (`ifort`), `NVID
  * `PENCIL_AXIS`              : sets the default pencil direction, one of [1,2,3] for [X,Y,Z]-aligned pencils; X-aligned is the default and should be optimal for all cases except for Z implicit diffusion, where using Z-pencils is recommended
  * `SINGLE_PRECISION`         : calculation will be carried out in single precision (the default precision is double)
  * `CONSTANT_COEFFS_POISSON`  : enables the use of a direct FFT solver for the pressure Poisson equation (if set to 0, an iterative multigrid solver based on the HYPRE library will be used. This option is only available for CPU compilation)
- * `CONSERVATIVE_MOMENTUM`    : solves the momentum equation in divergence form
- * `GPU`                      : enable GPU accelerated runs (requires the `FCOMP=NVIDIA`)
+ * `CONSERVATIVE_MOMENTUM`    : solves the momentum equation with advective terms in divergence form
+ * `SCALAR`                   : enables the transport equation for a scalar field (e.g., temperature)
+ * `BOUSSINESQ_BUOYANCY`      : enables thermal convection within each phase under the Boussinesq approximation
+ * `GPU`                      : enables GPU accelerated runs (requires the `FCOMP=NVIDIA`)
 
 Typing `make libs` will build the 2DECOMP&FFT/cuDecomp libraries; then typing `make` will compile the code and copy the executable `cans` to a `run/` folder; `make run` will also copy the default input files `*.in` under `src/` to the same `run/` folder.
 


### PR DESCRIPTION
The switch for scalar and buoyancy was missing.