### PR TITLE
Fix out-of-bounds issue in HIT forcing.

### DIFF
--- a/src/forcing.f90
+++ b/src/forcing.f90
@@ -20,7 +20,7 @@ module mod_forcing
     integer , intent(in), dimension(3) :: lo,hi
     real(rp), intent(in) :: alpha,dt
     real(rp), intent(in), dimension(3) :: l,dl
-    real(rp), intent(in), dimension(0:) :: zc,zf
+    real(rp), intent(in), dimension(lo(3)-1:) :: zc,zf
     real(rp), intent(inout), dimension(lo(1)-1:,lo(2)-1:,lo(3)-1:) :: u,v,w
     !
     real(rp) :: f0,factor

--- a/src/main.f90
+++ b/src/main.f90
@@ -289,7 +289,6 @@ program cans
   if(.not.restart) then
     istep = 0
     time = 0.
-    !$acc update self(zc,dzc,dzf)
     call initflow(inivel,bcvel,ng,lo,l,dl,zc,zf,dzc,dzf,rho12(2),mu12(2),bforce,is_wallturb,time,u,v,w,p)
 #if defined(_SCALAR)
     call initscal(inisca,bcsca,ng,lo,l,dl,dzf,zc,s)


### PR DESCRIPTION
Fixed a minor out-of-bounds error in the `lscale_forcing` subroutine and removes a superfluous `update self` directive.