### PR TITLE
Bugfixes.

### DIFF
--- a/src/correc.f90
+++ b/src/correc.f90
@@ -28,9 +28,6 @@ module mod_correc
     !
     rho = rho12(2); drho = rho12(1)-rho12(2)
     rhop = rho0
-    !
-    !factor = rkcoeffab(rkiter)*dt
-    !
     factori = dt*dli(1)
     factorj = dt*dli(2)
     !factork = dt*dzci!dli(3)

--- a/src/main.f90
+++ b/src/main.f90
@@ -339,7 +339,7 @@ program cans
 #else
   call cmpt_norm_curv(n,dli,dzci,dzfi,psi,normx,normy,normz,kappa)
 #endif
-  call boundp(cbcpsi,n,bcpsi,nb,is_bound,dl,dzc,kappa)
+  call boundp(cbcpsi,n,bcpre,nb,is_bound,dl,dzc,kappa)
   call boundp(cbcnor(:,:,1),n,bcnor(:,:,1),nb,is_bound,dl,dzc,normx)
   call boundp(cbcnor(:,:,2),n,bcnor(:,:,2),nb,is_bound,dl,dzc,normy)
   call boundp(cbcnor(:,:,3),n,bcnor(:,:,3),nb,is_bound,dl,dzc,normz)
@@ -485,7 +485,7 @@ program cans
 #endif
     if(mod(istep,icheck) == 0) then
       if(myid == 0) print*, 'Checking stability and divergence...'
-      call chkdt(n,dl,dzci,dzfi,is_solve_ns,is_track_interface,mu12,rho12,sigma,gacc,u,v,w,dt_cfl,gam,seps)
+      call chkdt(n,dl,dzci,dzfi,is_solve_ns,is_track_interface,mu12,rho12,sigma,gacc,u,v,w,dt_cfl,gam,seps,ka12,cp12)
       dt = min(cfl*dt_cfl,dtmax); if(dt_f > 0.) dt = dt_f
       if(myid == 0) print*, 'dt_cfl = ', dt_cfl, 'dt = ', dt
       if(dt_cfl < small) then

--- a/src/output.f90
+++ b/src/output.f90
@@ -481,14 +481,14 @@ module mod_output
           end do
         end do
       end do
-      call MPI_ALLREDUCE(MPI_IN_PLACE,um(1,1),ng(1)*ng(2),MPI_REAL_RP,MPI_SUM,MPI_COMM_WORLD,ierr)
-      call MPI_ALLREDUCE(MPI_IN_PLACE,vm(1,1),ng(1)*ng(2),MPI_REAL_RP,MPI_SUM,MPI_COMM_WORLD,ierr)
-      call MPI_ALLREDUCE(MPI_IN_PLACE,wm(1,1),ng(1)*ng(2),MPI_REAL_RP,MPI_SUM,MPI_COMM_WORLD,ierr)
-      call MPI_ALLREDUCE(MPI_IN_PLACE,u2(1,1),ng(1)*ng(2),MPI_REAL_RP,MPI_SUM,MPI_COMM_WORLD,ierr)
-      call MPI_ALLREDUCE(MPI_IN_PLACE,v2(1,1),ng(1)*ng(2),MPI_REAL_RP,MPI_SUM,MPI_COMM_WORLD,ierr)
-      call MPI_ALLREDUCE(MPI_IN_PLACE,w2(1,1),ng(1)*ng(2),MPI_REAL_RP,MPI_SUM,MPI_COMM_WORLD,ierr)
-      call MPI_ALLREDUCE(MPI_IN_PLACE,uv(1,1),ng(1)*ng(2),MPI_REAL_RP,MPI_SUM,MPI_COMM_WORLD,ierr)
-      call MPI_ALLREDUCE(MPI_IN_PLACE,uw(1,1),ng(1)*ng(2),MPI_REAL_RP,MPI_SUM,MPI_COMM_WORLD,ierr)
+      call MPI_ALLREDUCE(MPI_IN_PLACE,um(1,1),ng(2)*ng(3),MPI_REAL_RP,MPI_SUM,MPI_COMM_WORLD,ierr)
+      call MPI_ALLREDUCE(MPI_IN_PLACE,vm(1,1),ng(2)*ng(3),MPI_REAL_RP,MPI_SUM,MPI_COMM_WORLD,ierr)
+      call MPI_ALLREDUCE(MPI_IN_PLACE,wm(1,1),ng(2)*ng(3),MPI_REAL_RP,MPI_SUM,MPI_COMM_WORLD,ierr)
+      call MPI_ALLREDUCE(MPI_IN_PLACE,u2(1,1),ng(2)*ng(3),MPI_REAL_RP,MPI_SUM,MPI_COMM_WORLD,ierr)
+      call MPI_ALLREDUCE(MPI_IN_PLACE,v2(1,1),ng(2)*ng(3),MPI_REAL_RP,MPI_SUM,MPI_COMM_WORLD,ierr)
+      call MPI_ALLREDUCE(MPI_IN_PLACE,w2(1,1),ng(2)*ng(3),MPI_REAL_RP,MPI_SUM,MPI_COMM_WORLD,ierr)
+      call MPI_ALLREDUCE(MPI_IN_PLACE,uv(1,1),ng(2)*ng(3),MPI_REAL_RP,MPI_SUM,MPI_COMM_WORLD,ierr)
+      call MPI_ALLREDUCE(MPI_IN_PLACE,uw(1,1),ng(2)*ng(3),MPI_REAL_RP,MPI_SUM,MPI_COMM_WORLD,ierr)
       um(:,:) =      um(:,:)*grid_area_ratio
       vm(:,:) =      vm(:,:)*grid_area_ratio
       wm(:,:) =      wm(:,:)*grid_area_ratio

--- a/src/param.f90
+++ b/src/param.f90
@@ -20,9 +20,6 @@ real(rp), parameter :: eps = 0._rp
 #endif
 real(rp), parameter :: small = epsilon(1._rp)*10**(precision(1._rp)/2)
 character(len=100), parameter :: datadir = 'data/'
-real(rp), parameter, dimension(2,3) :: rkcoeff = reshape([32._rp/60._rp,  0._rp        , &
-                                                          25._rp/60._rp, -17._rp/60._rp, &
-                                                          45._rp/60._rp, -25._rp/60._rp], shape(rkcoeff))
 !
 ! variables to be determined from the input file
 !

--- a/src/rk.f90
+++ b/src/rk.f90
@@ -17,7 +17,7 @@ module mod_rk
                 bforce,gacc,sigma,rho_av,rho12,mu12,beta12,rho0,psi,kappa,p,pn,po,s, &
                 psio,psiflx_x,psiflx_y,psiflx_z,u,v,w)
     !
-    ! RK3 scheme for time integration of the momentum equations
+    ! AB2 scheme for time integration of the momentum equations
     !
     implicit none
     real(rp), intent(in), dimension(2) :: rkpar
@@ -122,7 +122,7 @@ module mod_rk
   subroutine rk_scal(rkpar,n,dli,dzci,dzfi,dt,ssource,rho12,ka12,cp12,psi,u,v,w,psio,psiflx_x,psiflx_y,psiflx_z,s)
     use mod_scal, only: scal_ad
     !
-    ! RK3 scheme for time integration of the scalar field
+    ! AB2 scheme for time integration of the scalar field
     !
     implicit none
     real(rp), intent(in   ), dimension(2) :: rkpar
@@ -187,7 +187,7 @@ module mod_rk
 #endif
     use mod_two_fluid   , only: clip_field
     !
-    ! RK3 scheme for time integration of the phase field
+    ! AB2 scheme for time integration of the phase field
     !
     implicit none
     real(rp), intent(in   ), dimension(2) :: rkpar

--- a/src/scal.f90
+++ b/src/scal.f90
@@ -165,6 +165,6 @@ module mod_scal
     !$acc end data
     !$acc wait(1)
     flux(:) = [flux_x,flux_y,flux_z]
-    call MPI_ALLREDUCE(MPI_IN_PLACE,flux(3),3,MPI_REAL_RP,MPI_SUM,MPI_COMM_WORLD,ierr)
+    call MPI_ALLREDUCE(MPI_IN_PLACE,flux,3,MPI_REAL_RP,MPI_SUM,MPI_COMM_WORLD,ierr)
   end subroutine cmpt_scalflux
 end module mod_scal

--- a/src/solver_vc.f90
+++ b/src/solver_vc.f90
@@ -78,14 +78,21 @@ module mod_solver_vc
     !
     comm_hypre = MPI_COMM_WORLD
     !
-    sgn(:,:) = 0._rp
+    sgn(:,:)    = 0._rp
+    factor(:,:) = 0._rp
     do q=1,3
       do qq=0,1
         if(is_bound(qq,q)) then
           select case(cbc(qq,q))
           case('N')
             sgn(qq,q)    =  1._rp
-            factor(qq,q) = 1.d0/dli(q)*bc(qq,q) ! N.B.: only valid for constant grid spacing
+            if(q == 3) then
+              if(qq == 0) factor(qq,q) =  dzci(lo(3)-1)**(-1)*bc(qq,q)
+              if(qq == 1) factor(qq,q) = -dzci(hi(3)  )**(-1)*bc(qq,q)
+            else
+              if(qq == 0) factor(qq,q) =  dli(q)**(-1)*bc(qq,q)
+              if(qq == 1) factor(qq,q) = -dli(q)**(-1)*bc(qq,q)
+            end if
           case('D')
             sgn(qq,q)    = -1._rp
             factor(qq,q) = -2.d0*bc(qq,q)

--- a/src/two_fluid.f90
+++ b/src/two_fluid.f90
@@ -203,9 +203,9 @@ module mod_two_fluid
           dpsidy = (psiyp-psiym)*dli(2)
           dpsidz = (psizp-psizm)*dzfi(k)
           norm   = sqrt(dpsidx**2+dpsidy**2+dpsidz**2)
-          dpsidx = dpsidx/norm
-          dpsidy = dpsidy/norm
-          dpsidz = dpsidz/norm
+          normx(i,j,k) = dpsidx/norm
+          normy(i,j,k) = dpsidy/norm
+          normz(i,j,k) = dpsidz/norm
         end do
       end do
     end do


### PR DESCRIPTION
- Fixes `dt_cfl` recomputation to include scalar diffusion in the main time loop; it was only being done at initialization.
- Other minor bugfixes related to reduction sizes.