### PR TITLE
Add optional CDI and standard THINC formulations

### DIFF
--- a/build.conf
+++ b/build.conf
@@ -14,8 +14,8 @@ TIMING=1                   # best = 1
 PENCIL_AXIS=1              # = 1/2/3 for X/Y/Z-aligned pencils
 SINGLE_PRECISION=0         # perform the whole calculation in single precision
 CONSTANT_COEFFS_POISSON=1
-INTERFACE_CAPTURING_VOF=0  # uses the THINC/QQ volume-of-fluid method to track the interface instead of the ACDI method
-SDF_NORMALS=1              # compute interface normals from an approximate signed-distance field
+INTERFACE_CAPTURING_VOF=0  # uses THINC/QQ volume-of-fluid instead of the ACDI pathway
+SDF_NORMALS=1              # default: ACDI or SDF-based THINC reconstruction and normals
 #
 # GPU-related
 #

--- a/docs/INFO_COMPILING.md
+++ b/docs/INFO_COMPILING.md
@@ -21,8 +21,8 @@ TIMING=1                   # best = 1
 PENCIL_AXIS=1              # = 1/2/3 for X/Y/Z-aligned pencils
 SINGLE_PRECISION=0         # perform the whole calculation in single precision
 CONSTANT_COEFFS_POISSON=1  # the fast mode for solving the pressure equation
-INTERFACE_CAPTURING_VOF=0  # uses the THINC/QQ volume-of-fluid method to track the interface instead of the ACDI method
-SDF_NORMALS=1              # computes interface normals from an approximate signed-distance field (default)
+INTERFACE_CAPTURING_VOF=0  # uses THINC/QQ volume-of-fluid instead of the ACDI pathway
+SDF_NORMALS=1              # default: ACDI or SDF-based THINC reconstruction and normals
 #
 # GPU-related
 #
@@ -36,8 +36,8 @@ In this file, `FCOMP` can be one of `GNU` (`gfortran`), `INTEL` (`ifort`), `NVID
  * `PENCIL_AXIS`              : sets the default pencil direction, one of [1,2,3] for [X,Y,Z]-aligned pencils; X-aligned is the default and should be optimal for all cases except for Z implicit diffusion, where using Z-pencils is recommended
  * `SINGLE_PRECISION`         : calculation will be carried out in single precision (the default precision is double)
  * `CONSTANT_COEFFS_POISSON`  : enables the use of a direct FFT solver for the pressure Poisson equation (if set to 0, an iterative multigrid solver based on the HYPRE library will be used. This option is only available for CPU compilation)
- * `INTERFACE_CAPTURING_VOF`  : uses the THINC/QQ volume-of-fluid method to track the interface
- * `SDF_NORMALS`              : computes interface normals and curvature from an approximate signed-distance field for both ACDI and VoF; when disabled, the phase indicator is used directly
+ * `INTERFACE_CAPTURING_VOF`  : uses the THINC/QQ volume-of-fluid method instead of the ACDI diffuse-interface pathway
+ * `SDF_NORMALS`              : enables approximate signed-distance fields for interface transport, normals, and curvature (default); setting it to `0` uses CDI or standard THINC directly from the phase indicator without allocating a distance field
  * `SCALAR`                   : enables the transport equation for a scalar field (e.g., temperature)
  * `BOUSSINESQ_BUOYANCY`      : enables thermal convection within each phase under the Boussinesq approximation
  * `GPU`                      : enables GPU accelerated runs (requires the `FCOMP=NVIDIA`)

--- a/src/acdi.f90
+++ b/src/acdi.f90
@@ -72,7 +72,7 @@ module mod_acdi
     real(rp), intent(in   )                      :: gam,seps
     real(rp), intent(in   ), dimension(0:,0:,0:) :: u,v,w
     real(rp), intent(in   ), dimension(0:,0:,0:) :: normx,normy,normz
-    real(rp), intent(in   ), dimension(0:,0:,0:) :: phi
+    real(rp), intent(in   ), dimension(0:,0:,0:), optional :: phi
     real(rp), intent(inout), dimension(0:,0:,0:) :: psi
     real(rp), intent(out  ), dimension(: ,: ,: ) :: dpsidt
     real(rp), intent(out  ), dimension(0:,0:,0:), optional :: flux_x,flux_y,flux_z
@@ -89,7 +89,11 @@ module mod_acdi
     real(rp) :: normx_xm,normx_xp,normx_ym,normx_yp,normx_zm,normx_zp, &
                 normy_xm,normy_xp,normy_ym,normy_yp,normy_zm,normy_zp, &
                 normz_xm,normz_xp,normz_ym,normz_yp,normz_zm,normz_zp
+#if defined(_SDF_NORMALS)
     real(rp) :: phi_ccm,phi_mcc,phi_cmc,phi_ccc,phi_cpc,phi_pcc,phi_ccp
+#else
+    real(rp) :: psi_xm,psi_xp,psi_ym,psi_yp,psi_zm,psi_zp
+#endif
     real(rp) :: rn_01,rn_11,rn_02,rn_12,rn_03,rn_13
     !
     dxi = dli(1)
@@ -114,6 +118,7 @@ module mod_acdi
           psi_cpc = psi(i  ,j+1,k  )
           psi_ccp = psi(i  ,j  ,k+1)
           !
+#if defined(_SDF_NORMALS)
           phi_ccm = phi(i  ,j  ,k-1)
           phi_cmc = phi(i  ,j-1,k  )
           phi_mcc = phi(i-1,j  ,k  )
@@ -121,6 +126,7 @@ module mod_acdi
           phi_pcc = phi(i+1,j  ,k  )
           phi_cpc = phi(i  ,j+1,k  )
           phi_ccp = phi(i  ,j  ,k+1)
+#endif
           !
           u_mcc = u(i-1,j  ,k  )
           u_ccc = u(i  ,j  ,k  )
@@ -176,12 +182,27 @@ module mod_acdi
           rn_03 = normz_zm/(sqrt(normx_zm**2+normy_zm**2+normz_zm**2)+eps)
           rn_13 = normz_zp/(sqrt(normx_zp**2+normy_zp**2+normz_zp**2)+eps)
           !
+#if !defined(_SDF_NORMALS)
+          psi_xm = 0.5*(psi_ccc+psi_mcc)
+          psi_xp = 0.5*(psi_pcc+psi_ccc)
+          psi_ym = 0.5*(psi_ccc+psi_cmc)
+          psi_yp = 0.5*(psi_cpc+psi_ccc)
+          psi_zm = 0.5*(psi_ccc+psi_ccm)
+          psi_zp = 0.5*(psi_ccp+psi_ccc)
+          sharpxm = gam*psi_xm*(1.-psi_xm)*rn_01
+          sharpxp = gam*psi_xp*(1.-psi_xp)*rn_11
+          sharpym = gam*psi_ym*(1.-psi_ym)*rn_02
+          sharpyp = gam*psi_yp*(1.-psi_yp)*rn_12
+          sharpzm = gam*psi_zm*(1.-psi_zm)*rn_03
+          sharpzp = gam*psi_zp*(1.-psi_zp)*rn_13
+#else
           sharpxm = 0.25*gam*((1.-(tanh(0.25*(phi_ccc+phi_mcc)/seps))**2)*rn_01)
           sharpxp = 0.25*gam*((1.-(tanh(0.25*(phi_pcc+phi_ccc)/seps))**2)*rn_11)
           sharpym = 0.25*gam*((1.-(tanh(0.25*(phi_ccc+phi_cmc)/seps))**2)*rn_02)
           sharpyp = 0.25*gam*((1.-(tanh(0.25*(phi_cpc+phi_ccc)/seps))**2)*rn_12)
           sharpzm = 0.25*gam*((1.-(tanh(0.25*(phi_ccc+phi_ccm)/seps))**2)*rn_03)
           sharpzp = 0.25*gam*((1.-(tanh(0.25*(phi_ccp+phi_ccc)/seps))**2)*rn_13)
+#endif
           !
           ! transport
           !

--- a/src/main.f90
+++ b/src/main.f90
@@ -70,7 +70,7 @@ program cans
 #endif
 #if !defined(_INTERFACE_CAPTURING_VOF)
   use mod_acdi           , only: acdi_set_epsilon,acdi_set_gamma,acdi_cmpt_phi
-#else
+#elif defined(_SDF_NORMALS)
   use mod_vof_thinc_qq   , only: vof_thinc_cmpt_phi
 #endif
   use mod_two_fluid      , only: init2fl,cmpt_norm_curv => cmpt_norm_curv_youngs
@@ -192,8 +192,11 @@ program cans
   allocate(rhsbp%x(n(2),n(3),0:1), &
            rhsbp%y(n(1),n(3),0:1), &
            rhsbp%z(n(1),n(2),0:1))
-  allocate(psi,phi,kappa,normx,normy,normz,mold=pp)
+  allocate(psi,kappa,normx,normy,normz,mold=pp)
   allocate(psio,mold=pp)
+#if defined(_SDF_NORMALS)
+  allocate(phi,mold=pp)
+#endif
   allocate(psiflx_x,psiflx_y,psiflx_z,mold=pp)
 #if defined(_DEBUG)
   if(myid == 0) print*, 'This executable of CaNS was built with compiler: ', compiler_version()
@@ -327,15 +330,20 @@ program cans
   call boundp(cbcsca,n,bcsca,nb,is_bound,dl,dzc,s)
   !$acc wait
 #endif
-  !$acc enter data copyin(psi) create(phi,kappa,normx,normy,normz) async(1)
+  !$acc enter data copyin(psi) create(kappa,normx,normy,normz) async(1)
+#if defined(_SDF_NORMALS)
+  !$acc enter data create(phi) async(1)
+#endif
   !$acc enter data create(psio,psiflx_x,psiflx_y,psiflx_z) async(1)
   call boundp(cbcpsi,n,bcpsi,nb,is_bound,dl,dzc,psi)
   !$acc wait
   !
+#if defined(_SDF_NORMALS)
 #if !defined(_INTERFACE_CAPTURING_VOF)
   call acdi_cmpt_phi(n,seps,psi,phi)
 #else
   call vof_thinc_cmpt_phi(n,vof_thinc_beta,psi,phi)
+#endif
 #endif
 #if defined(_SDF_NORMALS)
   call cmpt_norm_curv(n,dli,dzci,dzfi,phi,normx,normy,normz,kappa)
@@ -409,10 +417,12 @@ program cans
       call tm_2fl(tm_coeff,n,dli,dzci,dzfi,dt,gam,seps,vof_thinc_beta,u,v,w,normx,normy,normz,phi,psi,psiflx_x,psiflx_y,psiflx_z)
       call bounduvw(cbcvel,n,bcvel,nb,is_bound,.false.,dl,dzc,dzf,psiflx_x,psiflx_y,psiflx_z)
       call boundp(cbcpsi,n,bcpsi,nb,is_bound,dl,dzc,psi)
+#if defined(_SDF_NORMALS)
 #if !defined(_INTERFACE_CAPTURING_VOF)
       call acdi_cmpt_phi(n,seps,psi,phi)
 #else
       call vof_thinc_cmpt_phi(n,vof_thinc_beta,psi,phi)
+#endif
 #endif
 #if defined(_SDF_NORMALS)
       call cmpt_norm_curv(n,dli,dzci,dzfi,phi,normx,normy,normz,kappa)

--- a/src/rk.f90
+++ b/src/rk.f90
@@ -197,7 +197,7 @@ module mod_rk
     real(rp), intent(in   ) :: gam,seps,beta,dt
     real(rp), intent(in   ), dimension(0:,0:,0:) :: u,v,w
     real(rp), intent(in   ), dimension(0:,0:,0:) :: normx,normy,normz
-    real(rp), intent(in   ), dimension(0:,0:,0:) :: phi
+    real(rp), intent(in   ), dimension(0:,0:,0:), optional :: phi
     real(rp), intent(inout), dimension(0:,0:,0:) :: psi
     real(rp), intent(out  ), dimension(0:,0:,0:) :: psiflx_x,psiflx_y,psiflx_z
     real(rp), target     , allocatable, dimension(:,:,:), save :: dpsidtrk_t,dpsidtrko_t
@@ -218,7 +218,7 @@ module mod_rk
 #if !defined(_INTERFACE_CAPTURING_VOF)
     call acdi_transport_pf(n,dli,dzci,dzfi,gam,seps,u,v,w,normx,normy,normz,phi,psi,dpsidtrk,psiflx_x,psiflx_y,psiflx_z)
 #else
-    call vof_thinc_transport_psi(n,dli,dzfi,beta,u,v,w,normx,normy,normz,phi,dpsidtrk,psiflx_x,psiflx_y,psiflx_z)
+    call vof_thinc_transport_psi(n,dli,dzfi,beta,u,v,w,normx,normy,normz,phi,psi,dpsidtrk,psiflx_x,psiflx_y,psiflx_z)
 #endif
     if(is_first) then
       !$acc kernels default(present) async(1)

--- a/src/vof_thinc_qq.f90
+++ b/src/vof_thinc_qq.f90
@@ -36,7 +36,7 @@ module mod_vof_thinc_qq
 #endif
   !
   contains
-  subroutine vof_thinc_transport_psi(n,dli,dzfi,beta,u,v,w,normx,normy,normz,phi,dpsidt,flux_x,flux_y,flux_z)
+  subroutine vof_thinc_transport_psi(n,dli,dzfi,beta,u,v,w,normx,normy,normz,phi,psi,dpsidt,flux_x,flux_y,flux_z)
     !
     ! compute right-hand side of the VoF transport equation
     !
@@ -50,12 +50,16 @@ module mod_vof_thinc_qq
     real(rp), intent(in   )                      :: beta
     real(rp), intent(in   ), dimension(0:,0:,0:) :: u,v,w
     real(rp), intent(in   ), dimension(0:,0:,0:) :: normx,normy,normz
-    real(rp), intent(in   ), dimension(0:,0:,0:) :: phi
+    real(rp), intent(in   ), dimension(0:,0:,0:), optional :: phi
+    real(rp), intent(inout), dimension(0:,0:,0:) :: psi
     real(rp), intent(out  ), dimension(: ,: ,: ) :: dpsidt
     real(rp), intent(out  ), dimension(0:,0:,0:) :: flux_x,flux_y,flux_z
     integer  :: i,j,k,ii,jj,kk
     real(rp) :: xx,yy,zz
     real(rp) :: vel_x,vel_y,vel_z, &
+#if !defined(_SDF_NORMALS)
+                lpsi_x,lpsi_y,lpsi_z, &
+#endif
                 lnormx_x,lnormy_y,lnormz_z, &
                 d_x,d_y,d_z,lflux_x,lflux_y,lflux_z
     !
@@ -93,9 +97,18 @@ module mod_vof_thinc_qq
           lnormy_y = normy(i,jj,k)
           lnormz_z = normz(i,j,kk)
           !
+#if defined(_SDF_NORMALS)
           d_x = phi(ii,j,k)
           d_y = phi(i,jj,k)
           d_z = phi(i,j,kk)
+#else
+          lpsi_x = psi(ii,j,k)
+          lpsi_y = psi(i,jj,k)
+          lpsi_z = psi(i,j,kk)
+          d_x = -.5_rp/beta*log(1._rp/(lpsi_x+eps)-1._rp+eps)
+          d_y = -.5_rp/beta*log(1._rp/(lpsi_y+eps)-1._rp+eps)
+          d_z = -.5_rp/beta*log(1._rp/(lpsi_z+eps)-1._rp+eps)
+#endif
           !
           lflux_x = 1._rp/(1._rp + exp(-2._rp*beta*(lnormx_x*xx + d_x)))
           lflux_y = 1._rp/(1._rp + exp(-2._rp*beta*(lnormy_y*yy + d_y)))


### PR DESCRIPTION
Standard CDI and THINC formulations are triggered if `SDF_NORMALS=0`, for the sake of completeness.